### PR TITLE
Encode attribute values when serializing to prevent attribute-injection XSS

### DIFF
--- a/XHTMLPurifier.js
+++ b/XHTMLPurifier.js
@@ -145,7 +145,16 @@ var XHTMLPurifier = (function() {
 						}
 					}
 
-					string += " " + name + "=\"" + value + "\"";
+					// SECURITY: HTML-entity-encode the attribute value so a value
+					// containing a double-quote (or angle brackets) cannot break out
+					// of the quoted attribute and inject additional attributes/handlers.
+					var encodedValue = String(value)
+						.replace(/&(?![a-zA-Z][a-zA-Z0-9]*;|#\d+;|#x[0-9a-fA-F]+;)/g, "&amp;")
+						.replace(/"/g, "&quot;")
+						.replace(/</g, "&lt;")
+						.replace(/>/g, "&gt;");
+
+					string += " " + name + "=\"" + encodedValue + "\"";
 				}
 			}
 			return string;

--- a/test.js
+++ b/test.js
@@ -64,4 +64,14 @@ describe('XHTMLPurifier', function() {
 						"    <tfoot>\n        <tr>\n            <td>\n                Testing\n            </td>\n        </tr>\n    </tfoot>\n</table>";
 		expect(XHTMLPurifier.purify(html)).to.equal(expected);
 	});
+
+	// security
+	it('entity-encodes attribute values to prevent attribute-injection XSS', function() {
+		var html = "<a href='http://x/' class='c\" onmouseover=\"x'>hi</a>";
+		var out = XHTMLPurifier.purify(html, true, true);
+		// the embedded double-quote must be entity-encoded, not emitted raw
+		expect(out).to.contain('&quot;');
+		// so the injected handler never becomes a live attribute
+		expect(out).to.not.match(/\son[a-z]+\s*=\s*"/i);
+	});
 });


### PR DESCRIPTION
Hi, and thank you for this library.

I came across a security issue while reviewing it and wanted to bring you a clean fix. When the purifier serializes its sanitized output, attribute values are written into double-quoted attributes without being HTML-entity-encoded. A value that contains a double-quote can break out of the attribute and inject a new one, including a JavaScript event handler like `onmouseover` or `onerror`. The injected handler survives sanitization and runs when the output is rendered, which is a sanitizer bypass that leads to cross-site scripting. It affects allowed attributes such as `class`, `style`, `title`, `alt`, `src`, and `href`.

Here is the behavior before the fix:

```js
const purify = require('xhtml-purifier');
purify.purify(`<a href='http://x/' class='c" onmouseover="x'>hi</a>`, true, true);
// returns: <p><a href="http://x/" class="c" onmouseover="x">hi</a></p>
// the onmouseover is now a live, separate attribute and fires on render
```

With the change, the same input produces `class="c&quot; onmouseover=&quot;x"`, so the handler stays inside the value and never executes.

The fix encodes the value in `attributeString()` before it is written. I only encode an ampersand when it is not already the start of an entity, so existing entities and URL query strings are not double-encoded and `purify()` stays idempotent.

I also added a regression test. The previously passing tests still pass. One unrelated test, "strips html with weird word tags," already fails on master independent of this change, so please do not let it distract from the review.

I reported this to you privately first and am opening the PR at your invitation. I scoped it to the attribute-injection issue and did not try to address other sanitization concerns here. Happy to follow up on anything, and thank you again for the library.

Michael


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attribute values are now HTML-entity-encoded when rendered, preventing injection via special characters.

* **Tests**
  * Added test to verify secure attribute value encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->